### PR TITLE
Enable debug without constants (issue #62)

### DIFF
--- a/PhpAmqpLib/Channel/AbstractChannel.php
+++ b/PhpAmqpLib/Channel/AbstractChannel.php
@@ -20,7 +20,12 @@ class AbstractChannel
 {
     public static $PROTOCOL_CONSTANTS_CLASS;
 
-    protected $debug;
+    /**
+     *
+     * @var boolean
+     */
+    protected $debug = false;
+
     /**
      *
      * @var AMQPConnection
@@ -66,6 +71,28 @@ class AbstractChannel
         default:
             throw new AMQPRuntimeException('Protocol: ' . $this->protocolVersion . ' not implemented.');
         }
+    }
+
+    /**
+     * Disables output of channel debug data
+     *
+     * @return \PhpAmqpLib\Channel\AbstractChannel
+     */
+    public function disableDebug()
+    {
+        $this->debug = false;
+        return $this;
+    }
+
+    /**
+     * Enables output of channel debug data
+     *
+     * @return \PhpAmqpLib\Channel\AbstractChannel
+     */
+    public function enableDebug()
+    {
+        $this->debug = true;
+        return $this;
     }
 
     public function getChannelId()

--- a/README.md
+++ b/README.md
@@ -76,13 +76,21 @@ $ php amqp_consumer_non_blocking.php
 
 ## Debugging ##
 
-If you want to know what's going on at a protocol level then add the following constant to your code:
+If you want to know what's going on at a protocol level then call the enableDebug() method in the AMQPChannel object:
 
 ```php
 <?php
-define('AMQP_DEBUG', true);
+$conn = new AMQPConnection(HOST, PORT, USER, PASS, VHOST);
+$ch = $conn->channel();
+
+// Enable debug at the protocol level
+$ch->enableDebug();
 
 ... more code
+
+// Disable debug
+$ch->disableDebug();
+
 
 ?>
 ```


### PR DESCRIPTION
Added support for callers to enable and disable channel debug output
without setting a constant.