### PR TITLE
CS: remove unused args/vars + enforced arg types + various CS fixes

### DIFF
--- a/PhpAmqpLib/Channel/AMQPChannel.php
+++ b/PhpAmqpLib/Channel/AMQPChannel.php
@@ -156,7 +156,7 @@ class AMQPChannel extends AbstractChannel
         if ($this->is_open === false || $this->connection === null) {
             $this->do_close();
 
-            return; // already closed
+            return null; // already closed
         }
         list($class_id, $method_id, $args) = $this->protocolWriter->channelClose(
             $reply_code,
@@ -864,20 +864,20 @@ class AMQPChannel extends AbstractChannel
      */
     protected function basic_cancel_from_server(AMQPReader $args)
     {
-        $consumerTag = $args->read_shortstr();
-
-        throw new AMQPBasicCancelException($consumerTag);
+        throw new AMQPBasicCancelException($args->read_shortstr());
     }
 
     /**
      * Confirm a cancelled consumer
      *
      * @param AMQPReader $args
+     * @return string
      */
     protected function basic_cancel_ok($args)
     {
         $consumer_tag = $args->read_shortstr();
         unset($this->callbacks[$consumer_tag]);
+
         return $consumer_tag;
     }
 
@@ -1137,7 +1137,7 @@ class AMQPChannel extends AbstractChannel
     public function publish_batch()
     {
         if (empty($this->batch_messages)) {
-            return;
+            return null;
         }
 
         /** @var AMQPWriter $pkt */

--- a/PhpAmqpLib/Connection/AMQPSocketConnection.php
+++ b/PhpAmqpLib/Connection/AMQPSocketConnection.php
@@ -32,7 +32,15 @@ class AMQPSocketConnection extends AbstractConnection
         $keepalive = false
     ) {
         $io = new SocketIO($host, $port, $timeout, $keepalive);
-
-        parent::__construct($user, $password, $vhost, $insist, $login_method, $login_response, $locale, $io);
+        parent::__construct(
+            $user,
+            $password,
+            $vhost,
+            $insist,
+            $login_method,
+            $login_response,
+            $locale,
+            $io
+        );
     }
 }

--- a/PhpAmqpLib/Connection/AMQPStreamConnection.php
+++ b/PhpAmqpLib/Connection/AMQPStreamConnection.php
@@ -19,6 +19,7 @@ class AMQPStreamConnection extends AbstractConnection
      * @param int $read_write_timeout
      * @param null $context
      * @param bool $keepalive
+     * @param int $heartbeat
      */
     public function __construct(
         $host,
@@ -36,9 +37,27 @@ class AMQPStreamConnection extends AbstractConnection
         $keepalive = false,
         $heartbeat = 0
     ) {
-        $io = new StreamIO($host, $port, $connection_timeout, $read_write_timeout, $context, $keepalive, $heartbeat);
+        $io = new StreamIO(
+            $host,
+            $port,
+            $connection_timeout,
+            $read_write_timeout,
+            $context,
+            $keepalive,
+            $heartbeat
+        );
 
-        parent::__construct($user, $password, $vhost, $insist, $login_method, $login_response, $locale, $io, $heartbeat);
+        parent::__construct(
+            $user,
+            $password,
+            $vhost,
+            $insist,
+            $login_method,
+            $login_response,
+            $locale,
+            $io,
+            $heartbeat
+        );
 
         // save the params for the use of __clone, this will overwrite the parent
         $this->construct_params = func_get_args();

--- a/PhpAmqpLib/Connection/AbstractConnection.php
+++ b/PhpAmqpLib/Connection/AbstractConnection.php
@@ -213,7 +213,7 @@ class AbstractConnection extends AbstractChannel
 
                 $host = $this->x_open($this->vhost, '', $this->insist);
                 if (!$host) {
-                    return; // we weren't redirected
+                    return null; // we weren't redirected
                 }
 
                 $this->setIsConnected(false);

--- a/PhpAmqpLib/Wire/AMQPReader.php
+++ b/PhpAmqpLib/Wire/AMQPReader.php
@@ -115,7 +115,7 @@ class AMQPReader extends AbstractClient
     protected function wait()
     {
         if ($this->timeout == 0) {
-            return;
+            return null;
         }
 
         // wait ..

--- a/PhpAmqpLib/Wire/GenericContent.php
+++ b/PhpAmqpLib/Wire/GenericContent.php
@@ -116,15 +116,15 @@ abstract class GenericContent
      * into a dictionary stored in this object as an attribute named
      * 'properties'.
      *
-     * @param AMQPReader $r
+     * @param AMQPReader $reader
      * NOTE: do not mutate $reader
      */
-    public function load_properties($r)
+    public function load_properties($reader)
     {
         // Read 16-bit shorts until we get one with a low bit set to zero
         $flags = array();
         while (true) {
-            $flag_bits = $r->read_short();
+            $flag_bits = $reader->read_short();
             $flags[] = $flag_bits;
             if (($flag_bits & 1) == 0) {
                 break;
@@ -142,7 +142,7 @@ abstract class GenericContent
                 $shift = 15;
             }
             if ($flag_bits & (1 << $shift)) {
-                $d[$key] = $r->{'read_' . $proptype}();
+                $d[$key] = $reader->{'read_' . $proptype}();
             }
 
             $shift -= 1;

--- a/PhpAmqpLib/Wire/IO/StreamIO.php
+++ b/PhpAmqpLib/Wire/IO/StreamIO.php
@@ -268,7 +268,6 @@ class StreamIO extends AbstractIO
         }
 
         $this->last_write = microtime(true);
-        return;
     }
 
     /**
@@ -288,13 +287,13 @@ class StreamIO extends AbstractIO
         // fwrite notice that the stream isn't ready
         if (strstr($errstr, 'Resource temporarily unavailable')) {
              // it's allowed to retry
-             return;
+            return null;
         }
 
         // stream_select warning that it has been interrupted by a signal
         if (strstr($errstr, 'Interrupted system call')) {
              // it's allowed while processing signals
-             return;
+            return null;
         }
 
         // raise all other issues to exceptions


### PR DESCRIPTION
According to #193, here's the PR that cleans unused code, remove uneeded args but also enforces some method argument type hinting.

Feedback and contribution is very welcomed.

Thanks,