### PR TITLE
Fixed signals to respond immediately instead of waiting for timeout.

### DIFF
--- a/PhpAmqpLib/Channel/AMQPChannel.php
+++ b/PhpAmqpLib/Channel/AMQPChannel.php
@@ -844,12 +844,18 @@ class AMQPChannel extends AbstractChannel
      *
      * @param string $consumer_tag
      * @param bool $nowait
+     * @param bool $noreturn
      * @return mixed
      */
-    public function basic_cancel($consumer_tag, $nowait = false)
+    public function basic_cancel($consumer_tag, $nowait = false, $noreturn = false)
     {
         list($class_id, $method_id, $args) = $this->protocolWriter->basicCancel($consumer_tag, $nowait);
         $this->send_method_frame(array($class_id, $method_id), $args);
+
+        if ($nowait || $noreturn) {
+            unset($this->callbacks[$consumer_tag]);
+            return $consumer_tag;
+        }
 
         return $this->wait(array(
             $this->waitHelper->get_wait('basic.cancel_ok')
@@ -876,6 +882,7 @@ class AMQPChannel extends AbstractChannel
     {
         $consumer_tag = $args->read_shortstr();
         unset($this->callbacks[$consumer_tag]);
+        return $consumer_tag;
     }
 
     /**

--- a/PhpAmqpLib/Wire/IO/StreamIO.php
+++ b/PhpAmqpLib/Wire/IO/StreamIO.php
@@ -9,7 +9,10 @@ use PhpAmqpLib\Wire\AMQPWriter;
 
 class StreamIO extends AbstractIO
 {
-    /** @var  string */
+    /** @var string */
+    protected $protocol;
+
+    /** @var string */
     protected $host;
 
     /** @var int */
@@ -36,8 +39,14 @@ class StreamIO extends AbstractIO
     /** @var float */
     protected $last_write;
 
+    /** @var array */
+    protected $last_error;
+
     /** @var resource */
     private $sock;
+
+    /** @var bool */
+    private $canSelectNull;
 
     /** @var bool */
     private $canDispatchPcntlSignal;
@@ -60,6 +69,7 @@ class StreamIO extends AbstractIO
         $keepalive = false,
         $heartbeat = 0
     ) {
+        $this->protocol = 'tcp';
         $this->host = $host;
         $this->port = $port;
         $this->connection_timeout = $connection_timeout;
@@ -67,8 +77,20 @@ class StreamIO extends AbstractIO
         $this->context = $context;
         $this->keepalive = $keepalive;
         $this->heartbeat = $heartbeat;
-        $this->canDispatchPcntlSignal = extension_loaded('pcntl') && function_exists('pcntl_signal_dispatch')
+        $this->canSelectNull = true;
+        $this->canDispatchPcntlSignal = extension_loaded('pcntl') 
+            && function_exists('pcntl_signal_dispatch')
             && (defined('AMQP_WITHOUT_SIGNALS') ? !AMQP_WITHOUT_SIGNALS : true);
+
+        if (is_null($this->context)) {
+            $this->context = stream_context_create();
+        } else {
+            $this->protocol = 'ssl';
+            // php bugs 41631 & 65137 prevent select null from working on ssl streams
+            if (PHP_VERSION_ID < 50436) {
+                $this->canSelectNull = false;
+            }
+        }
     }
 
     /**
@@ -81,33 +103,44 @@ class StreamIO extends AbstractIO
     {
         $errstr = $errno = null;
 
-        if ($this->context) {
-            $remote = sprintf('ssl://%s:%s', $this->host, $this->port);
-            $this->sock = @stream_socket_client(
-                $remote,
-                $errno,
-                $errstr,
-                $this->connection_timeout,
-                STREAM_CLIENT_CONNECT,
-                $this->context
-            );
-        } else {
-            $remote = sprintf('tcp://%s:%s', $this->host, $this->port);
-            $this->sock = @stream_socket_client(
-                $remote,
-                $errno,
-                $errstr,
-                $this->connection_timeout,
-                STREAM_CLIENT_CONNECT
+        $remote = sprintf(
+            '%s://%s:%s', 
+            $this->protocol,
+            $this->host,
+            $this->port
+        );
+
+        set_error_handler(array($this, 'error_handler'));
+        
+        $this->sock = stream_socket_client(
+            $remote,
+            $errno,
+            $errstr,
+            $this->connection_timeout,
+            STREAM_CLIENT_CONNECT,
+            $this->context
+        );
+        
+        restore_error_handler();
+
+        if (false === $this->sock) {
+            throw new AMQPRuntimeException(
+                sprintf(
+                    'Error Connecting to server(%s): %s ', 
+                    $errno,
+                    $errstr
+                ),
+                $errno
             );
         }
-
-        if (!$this->sock) {
-            throw new AMQPRuntimeException(sprintf(
-                'Error Connecting to server (%s): %s',
-                $errno,
-                $errstr
-            ), $errno);
+        
+        if (false === stream_socket_get_name($this->sock, true)) {
+            throw new AMQPRuntimeException(
+                sprintf(
+                    'Connection refused: %s ', 
+                    $remote
+                )
+            );
         }
 
         list($sec, $uSec) = MiscHelper::splitSecondsMicroseconds($this->read_write_timeout);
@@ -115,7 +148,16 @@ class StreamIO extends AbstractIO
             throw new AMQPIOException('Timeout could not be set');
         }
 
-        stream_set_blocking($this->sock, 1);
+        // php cannot capture signals while streams are blocking
+        if ($this->canDispatchPcntlSignal) {
+            stream_set_blocking($this->sock, 0);
+            stream_set_write_buffer($this->sock, 0);
+            if (function_exists('stream_set_read_buffer')) {
+                stream_set_read_buffer($this->sock, 0);
+            }
+        } else {
+            stream_set_blocking($this->sock, 1);
+        }
 
         if ($this->keepalive) {
             $this->enable_keepalive();
@@ -132,40 +174,60 @@ class StreamIO extends AbstractIO
     }
 
     /**
-     * @param $n
+     * @param $len
      * @throws \PhpAmqpLib\Exception\AMQPIOException
      * @return mixed|string
      */
-    public function read($n)
+    public function read($len)
     {
-        $res = '';
         $read = 0;
+        $data = '';
 
-        while ($read < $n && !feof($this->sock) && (false !== ($buf = fread($this->sock, $n - $read)))) {
+        while ($read < $len) {
             $this->check_heartbeat();
 
-            if ($buf === '') {
+            if (!is_resource($this->sock) || feof($this->sock)) {
+                throw new AMQPRuntimeException('Broken pipe or closed connection');
+            }
+
+            set_error_handler(array($this, 'error_handler'));
+            $buffer = fread($this->sock, ($len - $read));
+            restore_error_handler();
+
+            if ($buffer === false) {
+                throw new AMQPRuntimeException('Error receiving data');
+            }
+
+            if ($buffer === '') {
                 if ($this->canDispatchPcntlSignal) {
-                    pcntl_signal_dispatch();
+                    // prevent cpu from being consumed while waiting
+                    if ($this->canSelectNull) {
+                        $this->select(null, null);
+                        pcntl_signal_dispatch();
+                    } else {
+                        usleep(100000);
+                        pcntl_signal_dispatch();
+                    }
                 }
                 continue;
             }
 
-            $read += mb_strlen($buf, 'ASCII');
-            $res .= $buf;
-
-            $this->last_read = microtime(true);
+            $read += mb_strlen($buffer, 'ASCII');
+            $data .= $buffer;
         }
 
-        if (mb_strlen($res, 'ASCII') != $n) {
-            throw new AMQPIOException(sprintf(
-                'Error reading data. Received %s instead of expected %s bytes',
-                mb_strlen($res, 'ASCII'),
-                $n
-            ));
+        if (mb_strlen($data, 'ASCII') !== $len) {
+            throw new AMQPRuntimeException(
+                sprintf(
+                    'Error reading data. Received %s instead of expected %s bytes', 
+                    mb_strlen($data, 'ASCII'),
+                    $len
+                )
+            );
         }
 
-        return $res;
+        $this->last_read = microtime(true);
+        return $data;
     }
 
     /**
@@ -176,17 +238,24 @@ class StreamIO extends AbstractIO
      */
     public function write($data)
     {
+        $written = 0;
         $len = mb_strlen($data, 'ASCII');
-        while (true) {
-            if (is_null($this->sock)) {
+        
+        while ($written < $len) {
+
+            if (!is_resource($this->sock)) {
                 throw new AMQPRuntimeException('Broken pipe or closed connection');
             }
 
-            if (false === ($written = @fwrite($this->sock, $data))) {
+            set_error_handler(array($this, 'error_handler'));
+            $buffer = fwrite($this->sock, $data);
+            restore_error_handler();
+
+            if ($buffer === false) {
                 throw new AMQPRuntimeException('Error sending data');
             }
 
-            if ($written === 0) {
+            if ($buffer === 0 && feof($this->sock)) {
                 throw new AMQPRuntimeException('Broken pipe or closed connection');
             }
 
@@ -194,14 +263,42 @@ class StreamIO extends AbstractIO
                 throw new AMQPTimeoutException('Error sending data. Socket connection timed out');
             }
 
-            $len = $len - $written;
-            if ($len > 0) {
-                $data = mb_substr($data, 0 - $len, 0 - $len, 'ASCII');
-            } else {
-                $this->last_write = microtime(true);
-                break;
-            }
+            $written += $buffer;
+            $data = mb_substr($data, $buffer, mb_strlen($data, 'ASCII') - $buffer, 'ASCII');
         }
+
+        $this->last_write = microtime(true);
+        return;
+    }
+
+    /**
+     * Internal error handler to deal with stream and socket errors that need to be ignored
+     * 
+     * @param  int $errno
+     * @param  string $errstr
+     * @param  string $errfile
+     * @param  int $errline
+     * @param  array $errcontext
+     * @return void
+     */
+    public function error_handler($errno, $errstr, $errfile, $errline, $errcontext = null)
+    {
+        $this->last_error = compact('errno', 'errstr', 'errfile', 'errline', 'errcontext');
+
+        // fwrite notice that the stream isn't ready
+        if (strstr($errstr, 'Resource temporarily unavailable')) {
+             // it's allowed to retry
+             return;
+        }
+
+        // stream_select warning that it has been interrupted by a signal
+        if (strstr($errstr, 'Interrupted system call')) {
+             // it's allowed while processing signals
+             return;
+        }
+
+        // raise all other issues to exceptions
+        throw new \ErrorException($errstr, 0, $errno, $errfile, $errline);
     }
 
     /**
@@ -275,8 +372,13 @@ class StreamIO extends AbstractIO
         $read = array($this->sock);
         $write = null;
         $except = null;
+        $result = false;
 
-        return stream_select($read, $write, $except, $sec, $usec);
+        set_error_handler(array($this, 'error_handler'));
+        $result = stream_select($read, $write, $except, $sec, $usec);
+        restore_error_handler();
+
+        return $result;
     }
 
     /**

--- a/demo/amqp_consumer_signals.php
+++ b/demo/amqp_consumer_signals.php
@@ -1,0 +1,209 @@
+<?php
+
+include(__DIR__ . '/config.php');
+
+/**
+ * This class shows how you can use signals to handle consumers
+ * 
+ */
+class Consumer
+{
+    /**
+     * Setup signals and connection
+     */
+    public function __construct()
+    {
+        if (extension_loaded('pcntl')) {
+            define('AMQP_WITHOUT_SIGNALS', false);
+
+            pcntl_signal(SIGTERM, [$this, 'signalHandler']);
+            pcntl_signal(SIGHUP,  [$this, 'signalHandler']);
+            pcntl_signal(SIGINT,  [$this, 'signalHandler']);
+            pcntl_signal(SIGQUIT, [$this, 'signalHandler']);
+            pcntl_signal(SIGUSR1, [$this, 'signalHandler']);
+            pcntl_signal(SIGUSR2, [$this, 'signalHandler']);
+            pcntl_signal(SIGALRM, [$this, 'alarmHandler']);
+        } else {
+             echo 'Unable to process signals.' . PHP_EOL;
+             exit(1);
+        }
+
+        $ssl = null;
+        if (PORT === 5671) {
+            $ssl = [
+                'verify_peer'      => false,
+                'verify_peer_name' => false
+            ];
+        }
+        $this->_connection = new PhpAmqpLib\Connection\AMQPSSLConnection(
+            HOST, PORT, USER, PASS, VHOST, $ssl,
+            [
+                'read_write_timeout' => 30,    // needs to be at least 2x heartbeat
+                'keepalive'          => false, // doesn't work with ssl connections
+                'heartbeat'          => 15
+            ]
+        );
+    }
+
+    /**
+     * Signal handler
+     * 
+     * @param  int $signalNumber
+     * @return void
+     */
+    public function signalHandler($signalNumber)
+    {
+        echo 'Handling signal: #' . $signalNumber . PHP_EOL;
+        global $consumer;
+
+        switch ($signalNumber) {
+            case SIGTERM:  // 15 : supervisor default stop
+            case SIGQUIT:  // 3  : kill -s QUIT
+                $consumer->stopHard();
+                break;
+            case SIGINT:   // 2  : ctrl+c
+                $consumer->stop();
+                break;
+            case SIGHUP:   // 1  : kill -s HUP
+                $consumer->restart();
+                break;
+            case SIGUSR1:  // 10 : kill -s USR1
+                // send an alarm in 1 second
+                pcntl_alarm(1);
+                break;
+            case SIGUSR2:  // 12 : kill -s USR2
+                // send an alarm in 10 seconds
+                pcntl_alarm(10);
+                break;
+            default:
+                break;
+        }
+        return;
+    }
+
+    /**
+     * Alarm handler
+     * 
+     * @param  int $signalNumber
+     * @return void
+     */
+    public function alarmHandler($signalNumber)
+    {
+        echo 'Handling alarm: #' . $signalNumber . PHP_EOL;
+        global $consumer;
+
+        echo memory_get_usage(true) . PHP_EOL;
+        return;
+    }
+
+    /**
+     * Message handler
+     * 
+     * @param  PhpAmqpLib\Message\AMQPMessage $message
+     * @return void
+     */
+    public function messageHandler(PhpAmqpLib\Message\AMQPMessage $message)
+    {
+        echo "\n--------\n";
+        echo $message->body;
+        echo "\n--------\n";
+
+        $message->delivery_info['channel']->basic_ack($message->delivery_info['delivery_tag']);
+        if ($message->body === 'quit') {
+            $message->delivery_info['channel']->basic_cancel($message->delivery_info['consumer_tag']);
+        }
+    }
+
+    /**
+     * Start a consumer on an existing connection
+     * 
+     * @return void
+     */
+    public function start()
+    {
+        echo 'Starting consumer.' . PHP_EOL;
+        
+        $exchange = 'router';
+        $queue    = 'msgs';
+
+        $this->_channel = $this->_connection->channel();
+        $this->_channel->queue_declare($queue, false, true, false, false);
+        $this->_channel->exchange_declare($exchange, 'direct', false, true, false);
+        $this->_channel->queue_bind($queue, $exchange);
+        $this->_channel->basic_consume(
+            $queue, $this->_tag, false, false, false, false, 
+            [$this,'messageHandler'],
+            null,
+            ['x-cancel-on-ha-failover' => ['t', true]] // fail over to another node
+        );
+
+        echo 'Enter wait.' . PHP_EOL;
+        while (count($this->_channel->callbacks)) {
+            $this->_channel->wait();
+        }
+        echo 'Exit wait.' . PHP_EOL;
+    }
+
+    /**
+     * Restart the consumer on an existing connection
+     */
+    public function restart()
+    {
+        echo 'Restarting consumer.' . PHP_EOL;
+        $this->stopSoft();
+        $this->start();
+    }
+
+    /**
+     * Close the connection to the server
+     */
+    public function stopHard()
+    {
+        echo 'Stopping consumer by closing connection.' . PHP_EOL;
+        $this->_connection->close();
+    }
+
+    /**
+     * Close the channel to the server
+     */
+    public function stopSoft()
+    {
+        echo 'Stopping consumer by closing channel.' . PHP_EOL;
+        $this->_channel->close();
+    }
+    
+    /**
+     * Tell the server you are going to stop consuming
+     * It will finish up the last message and not send you any more
+     */
+    public function stop()
+    {
+        echo 'Stopping consumer by cancel command.' . PHP_EOL;
+        // this gets stuck and will not exit without the last two parameters set
+        $this->_channel->basic_cancel($this->_tag, false, true);
+    }
+
+    /**
+     * Current connection 
+     * 
+     * @var PhpAmqpLib\Connection\AMQPSSLConnection
+     */
+    protected $_connection = null;
+
+    /**
+     * Current channel
+     * 
+     * @var PhpAmqpLib\Channel\AMQPChannel
+     */
+    protected $_channel = null;
+    
+    /**
+     * Consumer tag
+     * 
+     * @var string
+     */
+    protected $_tag = 'consumer';
+}
+
+$consumer = new Consumer();
+$consumer->start();


### PR DESCRIPTION
Streams that are blocking are unable to interpret signals until a timeout occurs. When working on a connection with a higher timeout or using heartbeats to keep the connection alive, signals will not work. 

Workarounds have been mentioned which set a timeout and loop every x seconds to do a check but this is inefficient for the cpu. Using stream_select with a value of null is the easiest on resources while waiting for input. The only way that input will be caught is if the stream is not blocking.

Fixes #165
Fixes #192 

With a stressed connection and also when writing larger values to the stream the os can queue writes and result in hidden issues with the stream. I have removed the @ and have added a few allowed errors that can occur. Everything else will be raised as an exception so it will be easier for people to debug connection issues vs library issues.

Fixes #146 
Fixes #235 