### PR TITLE
Incorrect quoting of some sprintf formats.

### DIFF
--- a/PhpAmqpLib/Helper/MiscHelper.php
+++ b/PhpAmqpLib/Helper/MiscHelper.php
@@ -77,7 +77,7 @@ class MiscHelper
         // Iterate string
         for ($i = $j = 0; $i < $len; $i++) {
             // Convert to hexidecimal
-            $hexi .= sprintf('%02$x ', ord($data[$i]));
+            $hexi .= sprintf("%02$x ", ord($data[$i]));
 
             // Replace non-viewable bytes with '.'
             if (ord($data[$i]) >= 32) {
@@ -97,7 +97,7 @@ class MiscHelper
             // Add row
             if (++$j === 16 || $i === $len - 1) {
                 // Join the hexi / ascii output
-                $dump .= sprintf('%04$x  %-49s  %s', $offset, $hexi, $ascii);
+                $dump .= sprintf("%04$x  %-49s  %s", $offset, $hexi, $ascii);
 
                 // Reset vars
                 $hexi = $ascii = '';

--- a/tests/Unit/Helper/MiscHelperTest.php
+++ b/tests/Unit/Helper/MiscHelperTest.php
@@ -33,4 +33,12 @@ class MiscHelperTest extends \PHPUnit_Framework_TestCase
             array('3.123456', array(3, 123456)),
         );
     }
+
+    public function testHexDump()
+    {
+        $res = MiscHelper::hexdump('FM', 'hmtlOutput' == false, 'uppercase' == false, 'return' == true);
+        $this->assertRegExp('/000\s+46 4d\s+FM/', $res);
+        $res = MiscHelper::hexdump('FM', 'hmtlOutput' == false, 'uppercase' == true, 'return' == true);
+        $this->assertRegExp('/000\s+46 4D\s+FM/', $res);
+    }
 }

--- a/tests/Unit/Helper/MiscHelperTest.php
+++ b/tests/Unit/Helper/MiscHelperTest.php
@@ -36,9 +36,13 @@ class MiscHelperTest extends \PHPUnit_Framework_TestCase
 
     public function testHexDump()
     {
-        $res = MiscHelper::hexdump('FM', 'hmtlOutput' == false, 'uppercase' == false, 'return' == true);
+        $htmlOutput = false;
+        $uppercase = false;
+        $return = true;
+        $res = MiscHelper::hexdump('FM', $htmlOutput, $uppercase, $return);
         $this->assertRegExp('/000\s+46 4d\s+FM/', $res);
-        $res = MiscHelper::hexdump('FM', 'hmtlOutput' == false, 'uppercase' == true, 'return' == true);
+        $uppercase = true;
+        $res = MiscHelper::hexdump('FM', $htmlOutput, $uppercase, $return);
         $this->assertRegExp('/000\s+46 4D\s+FM/', $res);
     }
 }


### PR DESCRIPTION
The format argument of sprintf should be bracketed in double quote if interpolation is  needed.
 The $x is supposed to expand to either x or X. The single quotes prevent this interpolation and instead are seen as a positional argument spec n$, which is incorrect here.

As it stands, the code generates a "sprintf(): Too few arguments : warning.
