### PR TITLE
abstractconnection prepare_content memory optimization

### DIFF
--- a/PhpAmqpLib/Connection/AbstractConnection.php
+++ b/PhpAmqpLib/Connection/AbstractConnection.php
@@ -419,14 +419,16 @@ class AbstractConnection extends AbstractChannel
 
         $pkt->write_octet(0xCE);
 
-        while ($body !== '') {
-            $bodyStart = ($this->frame_max - 8);
-            $payload = mb_substr($body, 0, $bodyStart, 'ASCII');
-            $body = (string)mb_substr($body, $bodyStart, mb_strlen($body, 'ASCII') - $bodyStart, 'ASCII');
+        // memory efficiency: walk the string instead of biting it. good for very large packets (100+mb)
+        $position = 0;
+        $bodyLength = mb_strlen($body,'8bit');
+        while ($position <= $bodyLength) {
+            $payload = mb_substr($body, $position, $this->frame_max - 8, '8bit');
+            $position += $this->frame_max - 8;
 
             $pkt->write_octet(3);
             $pkt->write_short($channel);
-            $pkt->write_long(mb_strlen($payload, 'ASCII'));
+            $pkt->write_long(mb_strlen($payload, '8bit'));
 
             $pkt->write($payload);
 

--- a/PhpAmqpLib/Connection/AbstractConnection.php
+++ b/PhpAmqpLib/Connection/AbstractConnection.php
@@ -419,10 +419,13 @@ class AbstractConnection extends AbstractChannel
 
         $pkt->write_octet(0xCE);
 
-        while ($body !== '') {
-            $bodyStart = ($this->frame_max - 8);
-            $payload = mb_substr($body, 0, $bodyStart, 'ASCII');
-            $body = (string)mb_substr($body, $bodyStart, mb_strlen($body, 'ASCII') - $bodyStart, 'ASCII');
+
+        // memory efficiency: walk the string instead of biting it. good for very large packets (100+mb)
+        $position = 0;
+        $bodyLength = mb_strlen($body,'ASCII');
+        while ($position <= $bodyLength) {
+            $payload = mb_substr($body, $position, $this->frame_max - 8, 'ASCII');
+            $position += $this->frame_max - 8;
 
             $pkt->write_octet(3);
             $pkt->write_short($channel);

--- a/PhpAmqpLib/Connection/AbstractConnection.php
+++ b/PhpAmqpLib/Connection/AbstractConnection.php
@@ -421,14 +421,14 @@ class AbstractConnection extends AbstractChannel
 
         // memory efficiency: walk the string instead of biting it. good for very large packets (100+mb)
         $position = 0;
-        $bodyLength = mb_strlen($body,'ASCII');
+        $bodyLength = mb_strlen($body,'8bit');
         while ($position <= $bodyLength) {
-            $payload = mb_substr($body, $position, $this->frame_max - 8, 'ASCII');
+            $payload = mb_substr($body, $position, $this->frame_max - 8, '8bit');
             $position += $this->frame_max - 8;
 
             $pkt->write_octet(3);
             $pkt->write_short($channel);
-            $pkt->write_long(mb_strlen($payload, 'ASCII'));
+            $pkt->write_long(mb_strlen($payload, '8bit'));
 
             $pkt->write($payload);
 

--- a/PhpAmqpLib/Connection/AbstractConnection.php
+++ b/PhpAmqpLib/Connection/AbstractConnection.php
@@ -419,16 +419,14 @@ class AbstractConnection extends AbstractChannel
 
         $pkt->write_octet(0xCE);
 
-        // memory efficiency: walk the string instead of biting it. good for very large packets (100+mb)
-        $position = 0;
-        $bodyLength = mb_strlen($body,'8bit');
-        while ($position <= $bodyLength) {
-            $payload = mb_substr($body, $position, $this->frame_max - 8, '8bit');
-            $position += $this->frame_max - 8;
+        while ($body !== '') {
+            $bodyStart = ($this->frame_max - 8);
+            $payload = mb_substr($body, 0, $bodyStart, 'ASCII');
+            $body = (string)mb_substr($body, $bodyStart, mb_strlen($body, 'ASCII') - $bodyStart, 'ASCII');
 
             $pkt->write_octet(3);
             $pkt->write_short($channel);
-            $pkt->write_long(mb_strlen($payload, '8bit'));
+            $pkt->write_long(mb_strlen($payload, 'ASCII'));
 
             $pkt->write($payload);
 

--- a/PhpAmqpLib/Connection/AbstractConnection.php
+++ b/PhpAmqpLib/Connection/AbstractConnection.php
@@ -420,7 +420,7 @@ class AbstractConnection extends AbstractChannel
         $pkt->write_octet(0xCE);
 
 
-        // memory efficiency: walk the string instead of biting it. good for very large packets (100+mb)
+        // memory efficiency: walk the string instead of biting it. good for very large packets (close in size to memory_limit setting)
         $position = 0;
         $bodyLength = mb_strlen($body,'ASCII');
         while ($position <= $bodyLength) {

--- a/PhpAmqpLib/Connection/AbstractConnection.php
+++ b/PhpAmqpLib/Connection/AbstractConnection.php
@@ -421,14 +421,14 @@ class AbstractConnection extends AbstractChannel
 
         // memory efficiency: walk the string instead of biting it. good for very large packets (100+mb)
         $position = 0;
-        $bodyLength = mb_strlen($body,'8bit');
+        $bodyLength = mb_strlen($body,'ASCII');
         while ($position <= $bodyLength) {
-            $payload = mb_substr($body, $position, $this->frame_max - 8, '8bit');
+            $payload = mb_substr($body, $position, $this->frame_max - 8, 'ASCII');
             $position += $this->frame_max - 8;
 
             $pkt->write_octet(3);
             $pkt->write_short($channel);
-            $pkt->write_long(mb_strlen($payload, '8bit'));
+            $pkt->write_long(mb_strlen($payload, 'ASCII'));
 
             $pkt->write($payload);
 


### PR DESCRIPTION
On a very specific use case the memory_limit of the php script was reached. It occurs when the protocl is abused and very large packets are passed through it.