### PR TITLE
add getter for method_queue

### DIFF
--- a/PhpAmqpLib/Channel/AbstractChannel.php
+++ b/PhpAmqpLib/Channel/AbstractChannel.php
@@ -139,6 +139,14 @@ class AbstractChannel
     }
 
     /**
+     * @return array
+     */
+    public function getMethodQueue()
+    {
+        return $this->method_queue;
+    }
+
+    /**
      * @param string $method_sig
      * @param string $args
      * @param $content


### PR DESCRIPTION
Before commit 64eb289c9f5721daa2bd3ad0f333c5b738580843 the property method_queue was public. For one of our project we use celery-php which uses php-amqplib as a dependency. 

To receive status messages from the result queue it is necessary to read the property method_queue. Since it is now protected this is not longer possible.