### PR TITLE
Fix timestamp description: it is milliseconds, not seconds

### DIFF
--- a/PhpAmqpLib/Wire/AMQPReader.php
+++ b/PhpAmqpLib/Wire/AMQPReader.php
@@ -354,7 +354,7 @@ class AMQPReader extends AbstractClient
 
     /**
      * Read and AMQP timestamp, which is a 64-bit integer representing
-     * seconds since the Unix epoch in 1-second resolution.
+     * milliseconds since the Unix epoch in 1-millisecond resolution.
      */
     public function read_timestamp()
     {


### PR DESCRIPTION
Spec says timestamp is measured in milliseconds since unix epoch rather than seconds.
See http://www.amqp.org/sites/amqp.org/files/amqp.pdf pages 17-18

> Type: timestamp
> &lt;type name="timestamp" class="primitive"/&gt;
> [...]
> Represents an approximate point in time using the Unix time_t encoding of
> UTC, but with a precision of milliseconds. For example, 1311704463521 repre-
> sents the moment 2011-07-26T18:21:03.521Z.
