### PR TITLE
isConnected was still true when broken pipe or close connection

### DIFF
--- a/PhpAmqpLib/Connection/AbstractConnection.php
+++ b/PhpAmqpLib/Connection/AbstractConnection.php
@@ -333,11 +333,11 @@ class AbstractConnection extends AbstractChannel
         }
 
         try {
-			$this->getIO()->write($data);
-		} catch (AMQPRuntimeException $e) {
-			$this->setIsConnected(false);
-			throw $e;
-		}
+            $this->getIO()->write($data);
+        } catch (AMQPRuntimeException $e) {
+            $this->setIsConnected(false);
+            throw $e;
+        }
     }
 
     protected function do_close()

--- a/PhpAmqpLib/Connection/AbstractConnection.php
+++ b/PhpAmqpLib/Connection/AbstractConnection.php
@@ -332,7 +332,12 @@ class AbstractConnection extends AbstractChannel
             ));
         }
 
-        $this->getIO()->write($data);
+        try {
+			$this->getIO()->write($data);
+		} catch (AMQPRuntimeException $e) {
+			$this->setIsConnected(false);
+			throw $e;
+		}
     }
 
     protected function do_close()


### PR DESCRIPTION
Reconnecting wasn't possible at a brokenpipe runtime exception because isConnected was still true.