### PR TITLE
Include PHP 7 and HHVM Nightly builds in testing suite

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,11 +5,15 @@ php:
   - 5.4
   - 5.5
   - 5.6
+  - 7.0
   - hhvm
-
+  - hhvm-nightly
+  
 matrix:
+  fast_finish: true
   allow_failures:
-    - php: hhvm
+    - php: 7.0
+    - php: hhvm-nightly
 
 before_script:
   - composer install --dev --prefer-source


### PR DESCRIPTION
Since HHVM tests already pass, it would be good to start testing the upcoming versions of PHP & HHVM. Of course we're allowing failures for those cases.