### PR TITLE
StreamIO::select() fix warning when catching a signal during stream_select

### DIFF
--- a/PhpAmqpLib/Wire/IO/StreamIO.php
+++ b/PhpAmqpLib/Wire/IO/StreamIO.php
@@ -276,7 +276,18 @@ class StreamIO extends AbstractIO
         $write = null;
         $except = null;
 
-        return stream_select($read, $write, $except, $sec, $usec);
+        $result = @stream_select($read, $write, $except, $sec, $usec);
+        /* stream_select return false when we catch a signal with pcntl_signal
+         * and generates a warning. Trying to avoid that here
+         */
+        if ($result === false) {
+            $err = error_get_last();
+            if (isset($err['message']) && stripos($err['message'], 'interrupted system call')) {
+                return stream_select($read, $write, $except, $sec, $usec);
+            }
+            return false;
+        }
+        return $result;
     }
 
     /**


### PR DESCRIPTION
Similar to problem in reactphp:
https://github.com/reactphp/react/issues/301
https://github.com/reactphp/react/issues/296
https://github.com/reactphp/react/pull/297

http://php.net/stream_select
On error FALSE is returned and a warning raised (this can happen if the system call is interrupted by an incoming signal).