### PR TITLE
Allow a max body size to be set per Channel

### DIFF
--- a/PhpAmqpLib/Channel/AbstractChannel.php
+++ b/PhpAmqpLib/Channel/AbstractChannel.php
@@ -46,7 +46,7 @@ class AbstractChannel
     /**
      * @var int
      */
-    protected $body_size_max;
+    protected $body_size_max = null;
 
     /** @var \PhpAmqpLib\Helper\Protocol\Protocol080|\PhpAmqpLib\Helper\Protocol\Protocol091 */
     protected $protocolWriter;
@@ -141,9 +141,8 @@ class AbstractChannel
         
         if ( $max_bytes > 0 ) {
             $this->body_size_max = $max_bytes;
-        }
-        else {
-            unset($this->body_size_max);
+        } else {
+            $this->body_size_max = null;
         }
     }
 
@@ -284,7 +283,7 @@ class AbstractChannel
 
             $body_received = bcadd($body_received, mb_strlen($payload, 'ASCII'), 0);
 
-            if ( isset($this->body_size_max) && $body_received > $this->body_size_max ) {
+            if ( ! is_null($this->body_size_max) && $body_received > $this->body_size_max ) {
                 $msg->is_truncated = true;
                 continue;
             }

--- a/PhpAmqpLib/Message/AMQPMessage.php
+++ b/PhpAmqpLib/Message/AMQPMessage.php
@@ -10,6 +10,8 @@ class AMQPMessage extends GenericContent
 {
     /** @var string */
     public $body;
+    public $body_size;
+    public $is_truncated = false;
 
     /** @var string */
     public $content_encoding;

--- a/README.md
+++ b/README.md
@@ -139,6 +139,17 @@ $msg->setBody($body2);
 $ch->basic_publish($msg, $exchange);
 ```
 
+## Truncating Large Messages ##
+
+AMQP imposes no limit on the size of messages; if a very large message is received by a consumer, PHP's memory limit may be reached
+within the library before the callback passed to `basic_consume` is called.
+
+To avoid this, you can call the method `setBodySizeLimit(int $bytes)` on your Channel object. Body sizes exceeding this will be truncated, 
+and delivered to your callback with a `$msg->is_truncated` flag set. The property `$msg->body_size` will reflect the true body size,
+which will be higher than `strlen($msg->body)` if the message has been truncated.
+
+By default, no truncation will occur. To disable truncation on a Channel that has had it enabled, pass `null` to `setBodySizeLimit`.
+
 ##UNIX Signals##
 
 If you have installed [PCNTL extension](http://www.php.net/manual/en/book.pcntl.php) dispatching of signal will be handled when consumer is not processing message.

--- a/README.md
+++ b/README.md
@@ -145,8 +145,12 @@ AMQP imposes no limit on the size of messages; if a very large message is receiv
 within the library before the callback passed to `basic_consume` is called.
 
 To avoid this, you can call the method `setBodySizeLimit(int $bytes)` on your Channel object. Body sizes exceeding this will be truncated, 
-and delivered to your callback with a `$msg->is_truncated` flag set. The property `$msg->body_size` will reflect the true body size,
-which will be higher than `strlen($msg->body)` if the message has been truncated.
+and delivered to your callback with a `$msg->is_truncated` flag set. The property `$msg->body_size` will reflect the true body size of
+a received message, which will be higher than `strlen($msg->body)` if the message has been truncated.
+
+Note that all data above the limit is read from the AMQP Channel and immediately discarded, so there is no way to retrieve it within your 
+callback. If you have another consumer which can handle messages with larger payloads, you can use `basic_reject` or `basic_nack` to tell
+the server (which still has a complete copy) to forward it to a Dead Letter Exchange.
 
 By default, no truncation will occur. To disable truncation on a Channel that has had it enabled, pass `null` to `setBodySizeLimit`.
 


### PR DESCRIPTION
If a very large message is received by a consumer, PHP's memory limit may be reached
before the basic_consume callback is even called. To avoid this, the Channel needs to avoid constructing the Message.

Proposed solution is a new public function setMaxBodySize(int $bytes) on Channel; body sizes exceeding this will be truncated, and $msg->is_truncated flag set. A new public property $msg->body_size reflects the true body size (i.e. it higher than strlen($msg->body)).

This allows the callback to check the flat and decide whether to use the truncated data, or nack the message, etc.

The default remains unlimited to avoid compatibility issues, although a default value based on `ini_set('memory_limit')` might be possible.