### PR TITLE
Heartbeat frames decrease timeout on wait_channel (AbstractConnection)

### DIFF
--- a/PhpAmqpLib/Connection/AbstractConnection.php
+++ b/PhpAmqpLib/Connection/AbstractConnection.php
@@ -564,11 +564,23 @@ class AbstractConnection extends AbstractChannel
      */
     protected function wait_channel($channel_id, $timeout = 0)
     {
+        // Keeping the original timeout unchanged.
+        $_timeout = $timeout;
         while (true) {
-            list($frame_type, $frame_channel, $payload) = $this->wait_frame($timeout);
+            $now = time();
+            list($frame_type, $frame_channel, $payload) = $this->wait_frame($_timeout);
 
             if ($frame_channel === 0 && $frame_type === 8) {
-                // skip heartbeat frames
+                // skip heartbeat frames and reduce the timeout by the time passed
+                if( $_timeout > 0 )
+                {
+                    $_timeout -= time() - $now;
+                    if( $_timeout <= 0 )
+                    {
+                        // If timeout has reached, throw the exception without calling wait_frame
+                        throw new AMQPTimeoutException( "Timeout waiting on channel");
+                    }
+                }
                 continue;
 
             } else {


### PR DESCRIPTION
We are calling ``wait()`` on channel specifying a timeout that we determined as the time to live of our consumer. The time to live is respected if there are messages being processed but also if we are waiting on the channel for new messages until the time to live defined (10 minutes). 

This worked ok until we enabled heartbeat every 30 seconds to keep connection open behind Amazon ELB. What happens is that we have a timeout of 600 seconds and then (if there are no messages in the queue):
```
wait_frame() is called with 600 seconds timeout
-- after 30 seconds
heartbeat frame is received 
wait_frame() is called with 600 seconds timeout
-- more 30 seconds
heartbeat frame is received 
wait_frame() is called with 600 seconds timeout
(...)
```

This means our consumer will never timeout and do not raise the ``AMQPTimeoutException`` which will kill the consumer.

Our scenario is to have the consumer killed after a defined time to live and [Supervisor](http://supervisord.org) will ensure that a new fresh PHP process is started to continue process mesages.

With this change, when the heartbeat frame is received, besides skipping the frame the next timeout to be used in the ``wait_frame`` is decreased by the time passed in the meantime.

The flow is then something like this (in case there are no messages in the queue):
```
wait_frame() is called with 600 seconds timeout
-- after 30 seconds
heartbeat frame is received 
wait_frame() is called with 570 seconds timeout
-- more 30 seconds
heartbeat frame is received 
wait_frame() is called with 540 seconds timeout
(...)
heartbeat frame is received 
wait_frame() is called with 30 seconds timeout
AMQPTimeoutException
```