### PR TITLE
Prevent UNEXPECTED_FRAME exception

### DIFF
--- a/PhpAmqpLib/Connection/AbstractConnection.php
+++ b/PhpAmqpLib/Connection/AbstractConnection.php
@@ -428,7 +428,7 @@ class AbstractConnection extends AbstractChannel
         // memory efficiency: walk the string instead of biting it. good for very large packets (close in size to memory_limit setting)
         $position = 0;
         $bodyLength = mb_strlen($body,'ASCII');
-        while ($position <= $bodyLength) {
+        while ($position < $bodyLength) {
             $payload = mb_substr($body, $position, $this->frame_max - 8, 'ASCII');
             $position += $this->frame_max - 8;
 

--- a/tests/Functional/AbstractPublishConsumeTest.php
+++ b/tests/Functional/AbstractPublishConsumeTest.php
@@ -72,6 +72,26 @@ abstract class AbstractPublishConsumeTest extends \PHPUnit_Framework_TestCase
         }
     }
 
+    public function testPublishPacketSizeLongMessage()
+    {
+        // Connection frame_max;
+        $frame_max = 131072;
+
+        // Publish 3 messages with sizes: packet size - 1, equal packet size and packet size + 1
+        for ($length = $frame_max - 9; $length <= $frame_max - 7; $length++) {
+            $this->msg_body = str_repeat('1', $length);
+
+            $msg = new AMQPMessage($this->msg_body, array(
+                'content_type' => 'text/plain',
+                'delivery_mode' => 1,
+                'correlation_id' => 'my_correlation_id',
+                'reply_to' => 'my_reply_to'
+            ));
+
+            $this->ch->basic_publish($msg, $this->exchange_name, $this->queue_name);
+        }
+    }
+
 
 
     public function process_msg($msg)


### PR DESCRIPTION
Prevent "UNEXPECTED_FRAME - expected method frame, got non method frame instead" exception when message body length is equal multiplication of 131064 bytes