### PR TITLE
Fixed fatal error in some cases on Channel.wait with timeout

### DIFF
--- a/PhpAmqpLib/Connection/AbstractConnection.php
+++ b/PhpAmqpLib/Connection/AbstractConnection.php
@@ -519,6 +519,12 @@ class AbstractConnection extends AbstractChannel
      */
     protected function wait_frame($timeout = 0)
     {
+        if (is_null($this->input))
+        {
+            $this->setIsConnected(false);
+            throw new AMQPRuntimeException('Broken pipe or closed connection');
+        }
+
         $currentTimeout = $this->input->getTimeout();
         $this->input->setTimeout($timeout);
 


### PR DESCRIPTION
Changed demo/amqp_consumer.php
```php
while (true)
{
    try
    {
        if (count($ch->callbacks))
        {
            $ch->wait(null, false, 1);
        }
    }
    catch (AMQPTimeoutException $e)
    {
    }
    catch (AMQPProtocolConnectionException $e)
    {
    }
}
```

If RabbitMQ restarts while this code is running it leads to PHP fatal error "Call to a member function getTimeout()"