### PR TITLE
Add .gitattributes to slim down composer packages.

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,14 @@
+/.editorconfig export-ignore
+/.gitattributes export-ignore
+/.gitignore export-ignore
+/.travis.yml export-ignore
+/Makefile export-ignore
+/NOTE.DEVELOPMENT.NOV.2011.md export-ignore
+/NOTE.THENETCIRCLE.md export-ignore
+/README.md export-ignore
+/benchmark export-ignore
+/bin/ci export-ignore
+/demo export-ignore
+/doc export-ignore
+/phpunit.xml export-ignore
+/tests export-ignore


### PR DESCRIPTION
When composer is used as a dependency manager for large web apps,
transferring lots of extra files (such as tests and documentation) can
be very time and bandwidth consuming. By using gitattributes we can
tell composer what files to ignore when distributing through composer.