### PR TITLE
AMQPConnection class is deprecated.

### DIFF
--- a/demo/amqp_consumer.php
+++ b/demo/amqp_consumer.php
@@ -1,13 +1,13 @@
 <?php
 
 include(__DIR__ . '/config.php');
-use PhpAmqpLib\Connection\AMQPConnection;
+use PhpAmqpLib\Connection\AMQPStreamConnection;
 
 $exchange = 'router';
 $queue = 'msgs';
 $consumer_tag = 'consumer';
 
-$conn = new AMQPConnection(HOST, PORT, USER, PASS, VHOST);
+$conn = new AMQPStreamConnection(HOST, PORT, USER, PASS, VHOST);
 $ch = $conn->channel();
 
 /*

--- a/demo/amqp_consumer_exclusive.php
+++ b/demo/amqp_consumer_exclusive.php
@@ -4,7 +4,7 @@
 // Set $queue name to test exclusiveness
 
 include(__DIR__ . '/config.php');
-use PhpAmqpLib\Connection\AMQPConnection;
+use PhpAmqpLib\Connection\AMQPStreamConnection;
 
 $exchange = 'fanout_exclusive_example_exchange';
 $queue = ''; // if empty let RabbitMQ create a queue name
@@ -12,7 +12,7 @@ $queue = ''; // if empty let RabbitMQ create a queue name
 // to test exclusiveness
 $consumer_tag = 'consumer' . getmypid();
 
-$conn = new AMQPConnection(HOST, PORT, USER, PASS, VHOST);
+$conn = new AMQPStreamConnection(HOST, PORT, USER, PASS, VHOST);
 $ch = $conn->channel();
 
 /*

--- a/demo/amqp_consumer_fanout_1.php
+++ b/demo/amqp_consumer_fanout_1.php
@@ -4,13 +4,13 @@
 // amqp_consumer_fanout_2.php to test
 
 include(__DIR__ . '/config.php');
-use PhpAmqpLib\Connection\AMQPConnection;
+use PhpAmqpLib\Connection\AMQPStreamConnection;
 
 $exchange = 'fanout_example_exchange';
 $queue = 'fanout_group_1';
 $consumer_tag = 'consumer' . getmypid();
 
-$conn = new AMQPConnection(HOST, PORT, USER, PASS, VHOST);
+$conn = new AMQPStreamConnection(HOST, PORT, USER, PASS, VHOST);
 $ch = $conn->channel();
 
 /*

--- a/demo/amqp_consumer_fanout_2.php
+++ b/demo/amqp_consumer_fanout_2.php
@@ -4,13 +4,13 @@
 // amqp_consumer_fanout_2.php to test
 
 include(__DIR__ . '/config.php');
-use PhpAmqpLib\Connection\AMQPConnection;
+use PhpAmqpLib\Connection\AMQPStreamConnection;
 
 $exchange = 'fanout_example_exchange';
 $queue = 'fanout_group_2'; // Let RabbitMQ create a queue name
 $consumer_tag = 'consumer' . getmypid();
 
-$conn = new AMQPConnection(HOST, PORT, USER, PASS, VHOST);
+$conn = new AMQPStreamConnection(HOST, PORT, USER, PASS, VHOST);
 $ch = $conn->channel();
 
 /*

--- a/demo/amqp_consumer_non_blocking.php
+++ b/demo/amqp_consumer_non_blocking.php
@@ -1,13 +1,13 @@
 <?php
 
 include(__DIR__ . '/config.php');
-use PhpAmqpLib\Connection\AMQPConnection;
+use PhpAmqpLib\Connection\AMQPStreamConnection;
 
 $exchange = 'router';
 $queue = 'msgs';
 $consumer_tag = 'consumer';
 
-$conn = new AMQPConnection(HOST, PORT, USER, PASS, VHOST);
+$conn = new AMQPStreamConnection(HOST, PORT, USER, PASS, VHOST);
 $ch = $conn->channel();
 
 /*

--- a/demo/amqp_ha_consumer.php
+++ b/demo/amqp_ha_consumer.php
@@ -1,7 +1,7 @@
 <?php
 
 include(__DIR__ . '/config.php');
-use PhpAmqpLib\Connection\AMQPConnection;
+use PhpAmqpLib\Connection\AMQPStreamConnection;
 use PhpAmqpLib\Wire\AMQPTable;
 
 $exchange = 'router';
@@ -10,7 +10,7 @@ $specific_queue = 'specific-haqueue';
 
 $consumer_tag = 'consumer';
 
-$conn = new AMQPConnection(HOST, PORT, USER, PASS, VHOST);
+$conn = new AMQPStreamConnection(HOST, PORT, USER, PASS, VHOST);
 $ch = $conn->channel();
 
 /*

--- a/demo/amqp_message_headers_recv.php
+++ b/demo/amqp_message_headers_recv.php
@@ -1,6 +1,6 @@
 <?php
 include(__DIR__ . '/config.php');
-use PhpAmqpLib\Connection\AMQPConnection;
+use PhpAmqpLib\Connection\AMQPStreamConnection;
 
 
 $binding_keys = array_slice($argv, 1);
@@ -10,7 +10,7 @@ if (empty($binding_keys)) {
 }
 
 
-$connection = new AMQPConnection(HOST, PORT, USER, PASS, VHOST);
+$connection = new AMQPStreamConnection(HOST, PORT, USER, PASS, VHOST);
 $channel = $connection->channel();
 
 $exchName = 'topic_headers_test';

--- a/demo/amqp_message_headers_snd.php
+++ b/demo/amqp_message_headers_snd.php
@@ -1,11 +1,11 @@
 <?php
 include(__DIR__ . '/config.php');
-use PhpAmqpLib\Connection\AMQPConnection;
+use PhpAmqpLib\Connection\AMQPStreamConnection;
 use PhpAmqpLib\Message\AMQPMessage;
 use PhpAmqpLib\Wire;
 
 
-$connection = new AMQPConnection(HOST, PORT, USER, PASS, VHOST);
+$connection = new AMQPStreamConnection(HOST, PORT, USER, PASS, VHOST);
 $channel = $connection->channel();
 
 $exchName = 'topic_headers_test';

--- a/demo/amqp_publisher.php
+++ b/demo/amqp_publisher.php
@@ -1,13 +1,13 @@
 <?php
 
 include(__DIR__ . '/config.php');
-use PhpAmqpLib\Connection\AMQPConnection;
+use PhpAmqpLib\Connection\AMQPStreamConnection;
 use PhpAmqpLib\Message\AMQPMessage;
 
 $exchange = 'router';
 $queue = 'msgs';
 
-$conn = new AMQPConnection(HOST, PORT, USER, PASS, VHOST);
+$conn = new AMQPStreamConnection(HOST, PORT, USER, PASS, VHOST);
 $ch = $conn->channel();
 
 /*

--- a/demo/amqp_publisher_exclusive.php
+++ b/demo/amqp_publisher_exclusive.php
@@ -1,12 +1,12 @@
 <?php
 
 include(__DIR__ . '/config.php');
-use PhpAmqpLib\Connection\AMQPConnection;
+use PhpAmqpLib\Connection\AMQPStreamConnection;
 use PhpAmqpLib\Message\AMQPMessage;
 
 $exchange = 'fanout_exclusive_example_exchange';
 
-$conn = new AMQPConnection(HOST, PORT, USER, PASS, VHOST);
+$conn = new AMQPStreamConnection(HOST, PORT, USER, PASS, VHOST);
 $ch = $conn->channel();
 
 /*

--- a/demo/amqp_publisher_fanout.php
+++ b/demo/amqp_publisher_fanout.php
@@ -1,12 +1,12 @@
 <?php
 
 include(__DIR__ . '/config.php');
-use PhpAmqpLib\Connection\AMQPConnection;
+use PhpAmqpLib\Connection\AMQPStreamConnection;
 use PhpAmqpLib\Message\AMQPMessage;
 
 $exchange = 'fanout_example_exchange';
 
-$conn = new AMQPConnection(HOST, PORT, USER, PASS, VHOST);
+$conn = new AMQPStreamConnection(HOST, PORT, USER, PASS, VHOST);
 $ch = $conn->channel();
 
 /*

--- a/demo/amqp_publisher_with_confirms.php
+++ b/demo/amqp_publisher_with_confirms.php
@@ -1,13 +1,13 @@
 <?php
 
-use PhpAmqpLib\Connection\AMQPConnection;
+use PhpAmqpLib\Connection\AMQPStreamConnection;
 use PhpAmqpLib\Message\AMQPMessage;
 
 include(__DIR__ . '/config.php');
 
 $exchange = 'someExchange';
 
-$conn = new AMQPConnection(HOST, PORT, USER, PASS, VHOST);
+$conn = new AMQPStreamConnection(HOST, PORT, USER, PASS, VHOST);
 $ch = $conn->channel();
 
 $ch->set_ack_handler(

--- a/demo/amqp_publisher_with_confirms_mandatory.php
+++ b/demo/amqp_publisher_with_confirms_mandatory.php
@@ -1,13 +1,13 @@
 <?php
 
-use PhpAmqpLib\Connection\AMQPConnection;
+use PhpAmqpLib\Connection\AMQPStreamConnection;
 use PhpAmqpLib\Message\AMQPMessage;
 
 include(__DIR__ . '/config.php');
 
 $exchange = 'someExchange';
 
-$conn = new AMQPConnection(HOST, PORT, USER, PASS, VHOST);
+$conn = new AMQPStreamConnection(HOST, PORT, USER, PASS, VHOST);
 $ch = $conn->channel();
 
 $ch->set_ack_handler(

--- a/demo/basic_cancel.php
+++ b/demo/basic_cancel.php
@@ -1,6 +1,6 @@
 <?php
 
-use PhpAmqpLib\Connection\AMQPConnection;
+use PhpAmqpLib\Connection\AMQPStreamConnection;
 use PhpAmqpLib\Helper\Protocol\Wait091;
 
 include(__DIR__ . '/config.php');
@@ -13,7 +13,7 @@ $consumer_tag = 'consumer';
  * indicating that it's able to receive and process basic.cancel frames by setting the field
  * 'consumer_cancel_notify' to true.
  */
-$conn = new AMQPConnection(HOST, PORT, USER, PASS, VHOST);
+$conn = new AMQPStreamConnection(HOST, PORT, USER, PASS, VHOST);
 $ch = $conn->channel();
 $ch->queue_declare($queue);
 

--- a/demo/basic_get.php
+++ b/demo/basic_get.php
@@ -1,13 +1,13 @@
 <?php
 
 include(__DIR__ . '/config.php');
-use PhpAmqpLib\Connection\AMQPConnection;
+use PhpAmqpLib\Connection\AMQPStreamConnection;
 use PhpAmqpLib\Message\AMQPMessage;
 
 $exchange = 'basic_get_test';
 $queue = 'basic_get_queue';
 
-$conn = new AMQPConnection(HOST, PORT, USER, PASS, VHOST);
+$conn = new AMQPStreamConnection(HOST, PORT, USER, PASS, VHOST);
 $ch = $conn->channel();
 
 /*

--- a/demo/basic_nack.php
+++ b/demo/basic_nack.php
@@ -9,13 +9,13 @@
 
 
 include(__DIR__ . '/config.php');
-use PhpAmqpLib\Connection\AMQPConnection;
+use PhpAmqpLib\Connection\AMQPStreamConnection;
 
 $exchange = 'router';
 $queue = 'msgs';
 $consumer_tag = 'consumer';
 
-$conn = new AMQPConnection(HOST, PORT, USER, PASS, VHOST);
+$conn = new AMQPStreamConnection(HOST, PORT, USER, PASS, VHOST);
 $ch = $conn->channel();
 
 $ch->queue_declare($queue, false, true, false, false);

--- a/demo/basic_qos.php
+++ b/demo/basic_qos.php
@@ -1,9 +1,9 @@
 <?php
 
 include(__DIR__ . '/config.php');
-use PhpAmqpLib\Connection\AMQPConnection;
+use PhpAmqpLib\Connection\AMQPStreamConnection;
 
-$conn = new AMQPConnection(HOST, PORT, USER, PASS, VHOST);
+$conn = new AMQPStreamConnection(HOST, PORT, USER, PASS, VHOST);
 
 $ch = $conn->channel();
 

--- a/demo/basic_return.php
+++ b/demo/basic_return.php
@@ -2,10 +2,10 @@
 
 require_once __DIR__ . '/../vendor/autoload.php';
 
-use PhpAmqpLib\Connection\AMQPConnection;
+use PhpAmqpLib\Connection\AMQPStreamConnection;
 use PhpAmqpLib\Message\AMQPMessage;
 
-$connection = new AMQPConnection('localhost', 5672, 'guest', 'guest');
+$connection = new AMQPStreamConnection('localhost', 5672, 'guest', 'guest');
 $channel = $connection->channel();
 
 // declare  exchange but don`t bind any queue

--- a/demo/batch_publish.php
+++ b/demo/batch_publish.php
@@ -8,13 +8,13 @@
 
 include(__DIR__ . '/config.php');
 
-use PhpAmqpLib\Connection\AMQPConnection;
+use PhpAmqpLib\Connection\AMQPStreamConnection;
 use PhpAmqpLib\Message\AMQPMessage;
 
 $exchange = 'bench_exchange';
 $queue = 'bench_queue';
 
-$conn = new AMQPConnection(HOST, PORT, USER, PASS, VHOST);
+$conn = new AMQPStreamConnection(HOST, PORT, USER, PASS, VHOST);
 $ch = $conn->channel();
 
 $ch->queue_declare($queue, false, false, false, false);

--- a/demo/delayed_message.php
+++ b/demo/delayed_message.php
@@ -1,12 +1,12 @@
 <?php
 
-use PhpAmqpLib\Connection\AMQPConnection;
+use PhpAmqpLib\Connection\AMQPStreamConnection;
 use PhpAmqpLib\Message\AMQPMessage;
 use PhpAmqpLib\Wire\AMQPTable;
 
 include(__DIR__ . '/config.php');
 
-$conn = new AMQPConnection(HOST, PORT, USER, PASS, VHOST);
+$conn = new AMQPStreamConnection(HOST, PORT, USER, PASS, VHOST);
 $ch = $conn->channel();
 
 /**

--- a/demo/e2e_bindings.php
+++ b/demo/e2e_bindings.php
@@ -1,12 +1,12 @@
 <?php
 
 include(__DIR__ . '/config.php');
-use PhpAmqpLib\Connection\AMQPConnection;
+use PhpAmqpLib\Connection\AMQPStreamConnection;
 
 $source = 'my_source_exchange';
 $dest = 'my_dest_exchange';
 
-$conn = new AMQPConnection(HOST, PORT, USER, PASS, VHOST);
+$conn = new AMQPStreamConnection(HOST, PORT, USER, PASS, VHOST);
 $ch = $conn->channel();
 
 $ch->exchange_declare($source, 'topic', false, true, false);

--- a/demo/queue_arguments.php
+++ b/demo/queue_arguments.php
@@ -1,7 +1,7 @@
 <?php
 
 include(__DIR__ . '/config.php');
-use PhpAmqpLib\Connection\AMQPConnection;
+use PhpAmqpLib\Connection\AMQPStreamConnection;
 use PhpAmqpLib\Wire\AMQPTable;
 
 $exchange = 'router';
@@ -10,7 +10,7 @@ $specific_queue = 'specific-haqueue';
 
 $consumer_tag = 'consumer';
 
-$conn = new AMQPConnection(HOST, PORT, USER, PASS, VHOST);
+$conn = new AMQPStreamConnection(HOST, PORT, USER, PASS, VHOST);
 $ch = $conn->channel();
 
 $ch->queue_declare('test11', false, true, false, false, false, new AMQPTable(array(


### PR DESCRIPTION
Updated demo code to use AMQPStreamConnection class instead of the deprecated AMQPConnection class. It has been officially deprecated since Nov. 2014, see: videlalvaro/php-amqplib@64eb289#diff-d22541aa1646efa4a61d570b8a0a0ff0