### PR TITLE
Fix Scrutinizer

### DIFF
--- a/.scrutinizer.yml
+++ b/.scrutinizer.yml
@@ -20,5 +20,5 @@ checks:
 
 tools:
     external_code_coverage:
-        timeout: 600
-        runs: 3
+        timeout: 1020
+        runs: 4


### PR DESCRIPTION
Travis CI can take 15 minutes to run (PHP 5.3).  So I've increased the timeout to wait for code coverage report to 17 minutes.

Also, it now waits for all 4 reports (5.3, 5.4, 5.5, and 5.6).