### PR TITLE
Support PHP 7.0

### DIFF
--- a/.scrutinizer.yml
+++ b/.scrutinizer.yml
@@ -21,4 +21,4 @@ checks:
 tools:
     external_code_coverage:
         timeout: 1020
-        runs: 4
+        runs: 5

--- a/.travis.yml
+++ b/.travis.yml
@@ -28,7 +28,7 @@ script:
   - vendor/bin/phpunit --coverage-text --coverage-clover=coverage.clover
 
 after_script:
-  - if [[ $TRAVIS_PHP_VERSION != 'hhvm' && $TRAVIS_PHP_VERSION != '7.0' ]]; then php vendor/bin/ocular code-coverage:upload --format=php-clover coverage.clover; fi
+  - if [[ $TRAVIS_PHP_VERSION != 'hhvm' ]]; then php vendor/bin/ocular code-coverage:upload --format=php-clover coverage.clover; fi
 
 services:
   rabbitmq

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,6 @@ php:
 matrix:
   fast_finish: true
   allow_failures:
-    - php: 7.0
     - php: hhvm-nightly
   include:
     - php: 5.3


### PR DESCRIPTION
It looks like, in it's current state, the library supports and passes PHP 7.  Since it will be released soon, do we want to remove PHP 7 from the allowed "failures section" of TravisCI?