### PR TITLE
Typos in the 'publish with confirms' examples.

### DIFF
--- a/demo/amqp_publisher_with_confirms.php
+++ b/demo/amqp_publisher_with_confirms.php
@@ -33,7 +33,7 @@ $ch->confirm_select();
 /*
     name: $exchange
     type: fanout
-    passive: false // don't check is an exchange with the same name exists
+    passive: false // don't check if an exchange with the same name exists
     durable: false // the exchange won't survive server restarts
     auto_delete: true //the exchange will be deleted once the channel is closed.
 */

--- a/demo/amqp_publisher_with_confirms_mandatory.php
+++ b/demo/amqp_publisher_with_confirms_mandatory.php
@@ -39,7 +39,7 @@ $ch->confirm_select();
 /*
     name: $exchange
     type: fanout
-    passive: false // don't check is an exchange with the same name exists
+    passive: false // don't check if an exchange with the same name exists
     durable: false // the exchange won't survive server restarts
     auto_delete: true //the exchange will be deleted once the channel is closed.
 */


### PR DESCRIPTION
Fixed typos in the 'publish with confirms' examples.