### PR TITLE
fix heartbeat

### DIFF
--- a/PhpAmqpLib/Wire/IO/StreamIO.php
+++ b/PhpAmqpLib/Wire/IO/StreamIO.php
@@ -210,7 +210,7 @@ class StreamIO extends AbstractIO
                 if ($this->canDispatchPcntlSignal) {
                     // prevent cpu from being consumed while waiting
                     if ($this->canSelectNull) {
-                        $this->select(null, null);
+                        $this->select($this->heartbeat ?  $this->heartbeat + 1 : null, null);
                         pcntl_signal_dispatch();
                     } else {
                         usleep(100000);


### PR DESCRIPTION
when the network connection is broken, the select never returns and
never recognizes the missing heartbeat. changing the select (null) to
select (heartbeat+1s) hotfixes this.

Tested with php-5.4.45 on Debian Wheezy and an iptables rule to block AMQP traffic. Tested with php-amqplib-v2.6.0, but rebased to master.