### PR TITLE
StreamIO: fix "bad write retry" in SSL mode with nonblocking I/O

### DIFF
--- a/PhpAmqpLib/Wire/IO/StreamIO.php
+++ b/PhpAmqpLib/Wire/IO/StreamIO.php
@@ -255,8 +255,15 @@ class StreamIO extends AbstractIO
                 throw new AMQPRuntimeException('Broken pipe or closed connection');
             }
 
-            set_error_handler(array($this, 'error_handler'));
-            $buffer = fwrite($this->sock, $data, 8192);
+			set_error_handler(array($this, 'error_handler'));
+			// OpenSSL's C library function SSL_write() can balk on buffers > 8192
+			// bytes in length, so we're limiting the write size here. On both TLS
+			// and plaintext connections, the write loop will continue until the
+			// buffer has been fully written.
+			// This behavior has been observed in OpenSSL dating back to at least
+			// September 2002:
+			// http://comments.gmane.org/gmane.comp.encryption.openssl.user/4361
+			$buffer = fwrite($this->sock, $data, 8192);
             restore_error_handler();
 
             if ($buffer === false) {

--- a/PhpAmqpLib/Wire/IO/StreamIO.php
+++ b/PhpAmqpLib/Wire/IO/StreamIO.php
@@ -256,7 +256,7 @@ class StreamIO extends AbstractIO
             }
 
             set_error_handler(array($this, 'error_handler'));
-            $buffer = fwrite($this->sock, $data);
+            $buffer = fwrite($this->sock, $data, 8192);
             restore_error_handler();
 
             if ($buffer === false) {
@@ -272,7 +272,10 @@ class StreamIO extends AbstractIO
             }
 
             $written += $buffer;
-            $data = mb_substr($data, $buffer, mb_strlen($data, 'ASCII') - $buffer, 'ASCII');
+
+            if ($buffer > 0) {
+                $data = mb_substr($data, $buffer, mb_strlen($data, 'ASCII') - $buffer, 'ASCII');
+            }
         }
 
         $this->last_write = microtime(true);

--- a/PhpAmqpLib/Wire/IO/StreamIO.php
+++ b/PhpAmqpLib/Wire/IO/StreamIO.php
@@ -255,15 +255,15 @@ class StreamIO extends AbstractIO
                 throw new AMQPRuntimeException('Broken pipe or closed connection');
             }
 
-			set_error_handler(array($this, 'error_handler'));
-			// OpenSSL's C library function SSL_write() can balk on buffers > 8192
-			// bytes in length, so we're limiting the write size here. On both TLS
-			// and plaintext connections, the write loop will continue until the
-			// buffer has been fully written.
-			// This behavior has been observed in OpenSSL dating back to at least
-			// September 2002:
-			// http://comments.gmane.org/gmane.comp.encryption.openssl.user/4361
-			$buffer = fwrite($this->sock, $data, 8192);
+            set_error_handler(array($this, 'error_handler'));
+            // OpenSSL's C library function SSL_write() can balk on buffers > 8192
+            // bytes in length, so we're limiting the write size here. On both TLS
+            // and plaintext connections, the write loop will continue until the
+            // buffer has been fully written.
+            // This behavior has been observed in OpenSSL dating back to at least
+            // September 2002:
+            // http://comments.gmane.org/gmane.comp.encryption.openssl.user/4361
+            $buffer = fwrite($this->sock, $data, 8192);
             restore_error_handler();
 
             if ($buffer === false) {


### PR DESCRIPTION
When a large frame is written to the wire over an SSL connection, PHP's OpenSSL extension behaves erroneously upon write failures in non-blocking mode. The fwrite call will return 0. However, if the variable containing the buffer is modified or reassigned, PHP will pass a different pointer to SSL_write(), causing the "bad write retry" error.

This behavior is also produced when a large frame (>= 49,152 bytes) is written directly to the wire with fwrite().

This patch resolves the issue by changing the following behavior:

  - Limits fwrite() to 8,192 bytes at a time
  - Does not reassign $data if 0 bytes are written

No API breakage. Unit tests are passing.

Datto is using php-amqplib internally and so far we have seen reliability greatly improved with this patch.