### PR TITLE
handle connection interruption in v2.6.0

### DIFF
--- a/PhpAmqpLib/Wire/IO/StreamIO.php
+++ b/PhpAmqpLib/Wire/IO/StreamIO.php
@@ -248,7 +248,7 @@ class StreamIO extends AbstractIO
             }
 
             set_error_handler(array($this, 'error_handler'));
-            $buffer = fwrite($this->sock, $data);
+            $buffer = fwrite($this->sock, $data, 8192);
             restore_error_handler();
 
             if ($buffer === false) {
@@ -264,7 +264,10 @@ class StreamIO extends AbstractIO
             }
 
             $written += $buffer;
-            $data = mb_substr($data, $buffer, mb_strlen($data, 'ASCII') - $buffer, 'ASCII');
+
+            if ($buffer > 0) {
+                $data = mb_substr($data, $buffer, mb_strlen($data, 'ASCII') - $buffer, 'ASCII');
+            }
         }
 
         $this->last_write = microtime(true);

--- a/PhpAmqpLib/Wire/IO/StreamIO.php
+++ b/PhpAmqpLib/Wire/IO/StreamIO.php
@@ -273,7 +273,7 @@ class StreamIO extends AbstractIO
             $written += $buffer;
 
             if ($buffer > 0) {
-                $data = mb_substr($data, $buffer, mb_strlen($data, 'ASCII') - $buffer, 'ASCII');
+                $data = substr($data, $buffer, strlen($data) - $buffer);
             }
         }
 

--- a/PhpAmqpLib/Wire/IO/StreamIO.php
+++ b/PhpAmqpLib/Wire/IO/StreamIO.php
@@ -202,7 +202,7 @@ class StreamIO extends AbstractIO
                 if ($this->canDispatchPcntlSignal) {
                     // prevent cpu from being consumed while waiting
                     if ($this->canSelectNull) {
-                        $this->select(null, null);
+                        $this->select($this->heartbeat ?  $this->heartbeat + 1 : null, null);
                         pcntl_signal_dispatch();
                     } else {
                         usleep(100000);


### PR DESCRIPTION
In a consumer, when the network connection is broken, select() never returns and
never recognizes the missing heartbeat. changing the select (null) to
select (heartbeat+1s) hotfixes this.

In a publisher, broken network connection is not recognized. Implementing write timeout fixes this.