### PR TITLE
FIXED AbstractCollection value de/encoding on PHP7

### DIFF
--- a/PhpAmqpLib/Wire/AMQPAbstractCollection.php
+++ b/PhpAmqpLib/Wire/AMQPAbstractCollection.php
@@ -170,10 +170,9 @@ abstract class AMQPAbstractCollection implements \Iterator
      */
     final protected function encodeCollection(array $val)
     {
-        foreach ($val as &$v) {
-            $v = $this->encodeValue($v);
+        foreach ($val as $k=>$v) {
+            $val[$k] = $this->encodeValue($v);
         }
-        unset($v);
 
         return $val;
     }
@@ -184,10 +183,9 @@ abstract class AMQPAbstractCollection implements \Iterator
      */
     final protected function decodeCollection(array $val)
     {
-        foreach ($val as &$v) {
-            $v = $this->decodeValue($v[1], $v[0]);
+        foreach ($val as $k=>$v) {
+            $val[$k] = $this->decodeValue($v[1], $v[0]);
         }
-        unset($v);
 
         return $val;
     }


### PR DESCRIPTION
the old decodeCollection function returned an array with uninitialized values. Changing the foreach loop to not use references solved this on PHP7.