### PR TITLE
Typo in Readme.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -261,7 +261,7 @@ The default value is `'0.9.1'`.
 
 ## Providing your own autoloader ##
 
-If for some reasone you don't want to use composer, then you need to have an autoloader in place fo the library classes. People have [reported](https://github.com/videlalvaro/php-amqplib/issues/61#issuecomment-37855050) to use this [autoloader](https://gist.github.com/jwage/221634) with success.
+If for some reason you don't want to use composer, then you need to have an autoloader in place fo the library classes. People have [reported](https://github.com/videlalvaro/php-amqplib/issues/61#issuecomment-37855050) to use this [autoloader](https://gist.github.com/jwage/221634) with success.
 
 ## Original README: ##
 


### PR DESCRIPTION
Spotted a spelling mistake - `reasone` > `reason`